### PR TITLE
Fixing esVersion to match Elastic Search version

### DIFF
--- a/grafana/grafana-provisioning/datasources/all.yml
+++ b/grafana/grafana-provisioning/datasources/all.yml
@@ -9,7 +9,7 @@ datasources:
   database: '[dmarc_aggregate-]YYYY-MM-DD'
   isDefault: true
   jsonData:
-    esVersion: 70
+    esVersion: 7.17.5
     timeField: 'date_range'
     interval: 'Daily'
   version: 1
@@ -22,7 +22,7 @@ datasources:
   database: '[dmarc_forensic-]YYYY-MM-DD'
   isDefault: false
   jsonData:
-    esVersion: 70
+    esVersion: 7.17.5
     timeField: 'arrival_date'
     interval: 'Daily'
   version: 1


### PR DESCRIPTION
This will hopefully save some folks a bit of trouble with the "Support for Elasticsearch versions after their end-of-life (currently versions < 7.10)" error.